### PR TITLE
Bugfixes

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -38,7 +38,7 @@ jobs:
           sudo smbget -R $LIIONSDEN_SMB_PATH/test-suite-small -U "$LIIONSDEN_SMB_USERNAME%$LIIONSDEN_SMB_PASSWORD"
 
       - name: Build the stack
-        run: docker-compose -f docker-compose.test.yml build harvester
+        run: touch .env.secret && docker-compose -f docker-compose.test.yml build harvester
 
       # Enable tmate debugging of manually-triggered workflows if the input option was provided
       - name: Setup tmate session
@@ -59,7 +59,7 @@ jobs:
 
       - name: Set up secrets
         run: |
-          echo "POSTGRES_PASSWORD=$POSTGRES_PASSWORD\nDJANGO_SECRET_KEY=$DJANGO_SECRET_KEY\nDJANGO_TEST=$DJANGO_TEST" >> .env.secret
+          echo "POSTGRES_PASSWORD=${POSTGRES_PASSWORD}\nDJANGO_SECRET_KEY=${DJANGO_SECRET_KEY}\nDJANGO_TEST=${DJANGO_TEST}" >> .env.secret
 
       - name: Build the stack
         run: docker-compose -f docker-compose.test.yml up -d --build app_test
@@ -67,7 +67,7 @@ jobs:
       # Enable tmate debugging of manually-triggered workflows if the input option was provided
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+#        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
 
       - name: Run tests
         run: docker-compose -f docker-compose.test.yml run --rm app_test python manage.py test

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -57,8 +57,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Set up secrets
+        run: |
+          echo "POSTGRES_PASSWORD=$POSTGRES_PASSWORD\nDJANGO_SECRET_KEY=$DJANGO_SECRET_KEY\nDJANGO_TEST=$DJANGO_TEST" >> .env.secret
+
       - name: Build the stack
-        run: touch .env.secret && docker-compose -f docker-compose.test.yml up -d --build app_test
+        run: docker-compose -f docker-compose.test.yml up -d --build app_test
 
       # Enable tmate debugging of manually-triggered workflows if the input option was provided
       - name: Setup tmate session

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -59,7 +59,9 @@ jobs:
 
       - name: Set up secrets
         run: |
-          echo "POSTGRES_PASSWORD=${POSTGRES_PASSWORD}\nDJANGO_SECRET_KEY=${DJANGO_SECRET_KEY}\nDJANGO_TEST=${DJANGO_TEST}" >> .env.secret
+          echo "POSTGRES_PASSWORD=$POSTGRES_PASSWORD" > .env.secret
+          echo "DJANGO_SECRET_KEY=$DJANGO_SECRET_KEY" >> .env.secret
+          echo "DJANGO_TEST=$DJANGO_TEST" >> .env.secret
 
       - name: Build the stack
         run: docker-compose -f docker-compose.test.yml up -d --build app_test
@@ -67,7 +69,7 @@ jobs:
       # Enable tmate debugging of manually-triggered workflows if the input option was provided
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
-#        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
 
       - name: Run tests
         run: docker-compose -f docker-compose.test.yml run --rm app_test python manage.py test

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -9,8 +9,8 @@ services:
     command: -p 5433
     volumes:
       - "${GALVANALYSER_DATA_PATH}:/var/lib/postgresql/data"
-    environment:
-      POSTGRES_PASSWORD: "galvanalyser"
+    env_file:
+      - .env.secret
     restart: unless-stopped
 
   app_test:
@@ -27,10 +27,8 @@ services:
     working_dir: /usr/app/backend_django
     command: ../server.sh
 #    command: tail -F anything
-    environment:
-      POSTGRES_PASSWORD: "galvanalyser"
-      DJANGO_SECRET_KEY: "long-and-insecure-key-12345"
-      DJANGO_TEST: "TRUE"
+    env_file:
+      - .env.secret
 
   harvester:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - "80:80"
     volumes:
      - ./frontend:/app
+     - /app/node_modules/
     working_dir: /app
     env_file:
      - ./.env

--- a/frontend/src/APIConnection.ts
+++ b/frontend/src/APIConnection.ts
@@ -111,7 +111,7 @@ export class APIConnection {
 
   create_user(username: string, email: string, password: string): Promise<User> {
     return fetch(
-      this.url + 'users/',
+      this.url + 'inactive_users/',
       {
         method: 'POST',
         headers: {accept: 'application/json', 'content-type': 'application/json'},

--- a/frontend/src/Login.tsx
+++ b/frontend/src/Login.tsx
@@ -121,6 +121,15 @@ export default function Login() {
       To activate a user, log in to Galvanalyser as an active user and
       select the appropriate inactive user from the 'users' tab on the left.
     </Typography>
+    <Button
+      fullWidth
+      variant="contained"
+      color="primary"
+      className={classes.submit}
+      onClick={()=>window.location.reload()}
+    >
+      Log in with another account
+    </Button>
   </Stack>
 
   const formContent = <Fragment>


### PR DESCRIPTION
- closes #48 - fixed incorrect API call endpoint
- closes #47 - added volume override for `/app/node_modules/`
- closes #49 - use `.env.secret` in tests; create `.env.secret` in GitHub tests from envvars