### PR TITLE
Subset timeseriesdata

### DIFF
--- a/backend/backend_django/galvanalyser/views.py
+++ b/backend/backend_django/galvanalyser/views.py
@@ -1117,6 +1117,8 @@ Searchable fields:
 View the TimeseriesData contents of the Column.
 
 Data are presented as a dictionary of observations where keys are row numbers and values are observation values.
+
+Can be filtered with querystring parameters `min` and `max`, and `mod` (modulo) by specifying a sample number.
         """
     ),
     data_listformat=extend_schema(
@@ -1125,6 +1127,8 @@ Data are presented as a dictionary of observations where keys are row numbers an
 View the TimeseriesData contents of the Column as a list.
         
 Data are presented as a list of observation values ordered by row number.
+
+Can be filtered with querystring parameters `min` and `max`, and `mod` (modulo) by specifying a sample number.
         """
     )
 )


### PR DESCRIPTION
Closes #1 

- TimeseriesData can be filtered using min, max, mod querystring parameters for both dictionary and list views
- min = minimum record/sample number (inclusive)
- max = maximum record/sample number (inclusive)
- mod = include only records where record/sample number divided by this value is equal to 1

- Frontend implementation of filters for graph preview
- Default values of 0-2000, mod 100